### PR TITLE
Check the accepted currencies on the Stellar Account

### DIFF
--- a/includes/class-wc-gateway-stellar.php
+++ b/includes/class-wc-gateway-stellar.php
@@ -186,7 +186,7 @@ class WC_Gateway_Stellar extends WC_Payment_Gateway {
 	public function payment_fields() {
 		$description = $this->get_description();
 
-		if( !empty( $description ) ) {
+		if( ! empty( $description ) ) {
 			echo wpautop( wptexturize( trim( $description ) ) );
 			echo wc_get_template( 'checkout/stellar-registration.php', array(), '', WC_Stellar()->template_path() );
 		}


### PR DESCRIPTION
Doesn't show the Stellar Gateway on the checkout page if the currency is not accepted by the stellar account.

For instances where the store can accept multiple currencies on checkout (with the required plugin activated) I was trying to look at ways to get the currency on the checkout page but I wasn't able to find this and it's not stored in the WC_Cart Object either.

Thanks :)
