### PR TITLE
Allow longer requests to Stellard

### DIFF
--- a/woocommerce-stellar-gateway.php
+++ b/woocommerce-stellar-gateway.php
@@ -436,6 +436,7 @@ final class WC_Stellar {
 				'method'  => 'POST',
 				'headers' => $headers,
 				'body'    => $request,
+				'timeout' => 30,
 			)
 		);
 


### PR DESCRIPTION
Default `wp_remote_post()` timeout is 5 seconds; however, I found requests
to the Stellar.org Stellard were typically taking longer than this to
complete. Bumping it to 30 seconds should be plenty of time to complete
the request while also dropping requests that have hung.
